### PR TITLE
Update action.yml to handle the Hedera version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     required: true
     default: false
     type: boolean
+  hederaVersion: 
+    description: 'Version of Hedera to use. Defaults to Mainnet version.'
+    required: false
+    default: 'v0.52.2' 
 outputs:
   accountId:
     description: "Hedera account id for a new account"


### PR DESCRIPTION
**Added Optional Input Parameter:**

1. Introduced hederaVersion as an optional input parameter in the action's metadata.
2. The default value for this parameter is set to the current Mainnet version (v0.52.2), ensuring compatibility with the latest release.